### PR TITLE
set pylibjpeg min version

### DIFF
--- a/doc/tutorials/installation.rst
+++ b/doc/tutorials/installation.rst
@@ -156,7 +156,7 @@ RLE images provided a suitable plugin is installed.
 
 Using pip::
 
-  pip install pylibjpeg pylibjpeg-libjpeg pylibjpeg-openjpeg pylibjpeg-rle
+  pip install "pylibjpeg>=1.1" pylibjpeg-libjpeg pylibjpeg-openjpeg pylibjpeg-rle
 
 
 .. _tut_install_dev:


### PR DESCRIPTION
due to API changes you shall be using at least 1.1, otherwise you have the lib installed, but `from pylibjpeg.pydicom.utils import get_pixel_data_decoders` is not valid

#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
